### PR TITLE
Align list items containing checkboxes vertically

### DIFF
--- a/styles/markdown-preview-default.less
+++ b/styles/markdown-preview-default.less
@@ -89,6 +89,9 @@
   & > ol {
     margin-bottom: @margin;
   }
+  & > ol label, & > ul label {
+    vertical-align: top;
+  }
 
 
   // Blockquotes --------------------


### PR DESCRIPTION
As you can see in the screenshot below, list items that contains a checkbox doesn't render well. The bullet that stands on the left side of the list item is wrongly aligned to the bottom and causes confusion when you have multiple multi lined list items containing checkboxes.

![captura de tela 2015-12-16 22 19 38](https://cloud.githubusercontent.com/assets/673884/11858973/35681b44-a445-11e5-945e-bf3115f4d3c1.png)

This PR ensures the behavior described above does not occur anymore.
